### PR TITLE
Animate ShabbosTimes background orbs with subtle motion

### DIFF
--- a/shabbostime/index.html
+++ b/shabbostime/index.html
@@ -1,25 +1,32 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
     <title>Shabbos Times</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="shabbos.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image" href="images/icons/icon-72x72.png">
     <link rel="apple-touch-icon" href="images/icons/icon-192x192.png">
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
     <script src="https://kit.fontawesome.com/0a7f654060.js" crossorigin="anonymous"></script>
-    <meta name="theme-color" content="#5f5eaa">
+    <meta name="theme-color" content="#ffffff">
 </head>
 <body onload="changeColor()">
-    <nav class="navbar navbar-collapse-lg navbar-dark">
-        <a class="navbar-brand active " href="index.html" id="colorlabel2">Shabbos Times</a>
-        <a class="navbar-brand " href="zmanim.html" id="zmanim">Zmanim</a>
+    <div class="background-orbs" aria-hidden="true">
+        <span class="orb orb-1"></span>
+        <span class="orb orb-2"></span>
+        <span class="orb orb-3"></span>
+    </div>
+
+    <nav class="navbar navbar-expand-lg app-nav">
+        <a class="navbar-brand active" href="index.html" id="colorlabel2">Shabbos Times</a>
+        <a class="navbar-brand" href="zmanim.html" id="zmanim">Zmanim</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
-        </button> 
+        </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
+            <ul class="navbar-nav ml-auto">
                 <li class="nav-item active">
                     <a class="nav-link" href="index.html">Shabbos Times<span class="sr-only">(current)</span></a>
                 </li>
@@ -35,30 +42,35 @@
             </ul>
         </div>
     </nav>
-    <div id="page">
-        <div class="header">
-            <h3 class="header" id="header"> Shabbos times for</h3>
+
+    <main class="app-shell">
+        <section class="hero-card" aria-label="Location lookup">
+            <p class="eyebrow">Weekly schedule</p>
+            <h1 class="header" id="header">Shabbos times for your area</h1>
+            <p class="subheader">Enter your ZIP code to see this week's candle lighting, parsha, havdalah, and upcoming holiday notes.</p>
             <div class="finder">
-                <input type="number" id="zip" placeholder="Zip Code" aria-label="Zip Code" aria-describedby="basic-addon2" autofocus>
-                <button class="btn btn-outline-primary" id="submit" type="button" onclick="find()"> Submit</button>
+                <label for="zip" class="sr-only">Zip code</label>
+                <input type="number" id="zip" placeholder="Zip Code" aria-label="Zip Code" aria-describedby="submit" autofocus>
+                <button class="btn" id="submit" type="button" onclick="find()">Find Times</button>
             </div>
-        </div>
-        <div class="candles">
-            <p id = "candleLighting"> </p>
-    
-        </div>
-        <div class="parsha">
-            <p id="parshalabel"></p>
-        
-    
-        </div>
-        <div class="havdala">
-            <p id = "havdala"> </p>
-        </div>
-       
-    </div>
+        </section>
+
+        <section id="page" class="info-grid" aria-live="polite">
+            <article class="info-card candles">
+                <p class="card-label">Candle Lighting</p>
+                <p id="candleLighting" class="value-text">—</p>
+            </article>
+            <article class="info-card parsha">
+                <p id="parshalabel" class="value-text">Torah portion: <span id="parsha">—</span></p>
+            </article>
+            <article class="info-card havdala">
+                <p class="card-label">Havdalah</p>
+                <p id="havdala" class="value-text">—</p>
+            </article>
+        </section>
+    </main>
+
     <script type="text/javascript" src="shabbos.js"></script>
-   
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>

--- a/shabbostime/shabbos.css
+++ b/shabbostime/shabbos.css
@@ -1,171 +1,301 @@
+:root {
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --text: #111827;
+  --muted: #4b5563;
+  --accent: #0a84ff;
+  --border: #dbe2ea;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  top: 0;
-  margin: 4px 7.5%;
-
-  color: white;
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 0%, #fff 0%, #f8f9fb 40%, #eceef3 100%);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
 }
 
-#gpt{
- display: contents;
- margin:0;
- padding:0 ;
- border:none;
- color:white;
-}
-.navbar .active{
-  font-weight: bolder;
-  border-bottom: 2px solid #fff;
-}
-.psummary{
-  margin:20px 0 5px;
+.background-orbs {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
 }
 
-#page {
-  display: grid;
-  grid-template-areas:
-    "header header header"
-    "candles parsha havdala"
-    "holiday holiday holiday ";
-  grid-template-columns: 1fr 1fr 1fr;
-  justify-content: space-evenly;
+.orb {
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(40px);
+  opacity: 0.45;
+  will-change: transform;
 }
+
+.orb-1 {
+  width: 280px;
+  height: 280px;
+  background: #75b8ff;
+  top: 80px;
+  left: -80px;
+  animation: driftOrbOne 28s ease-in-out infinite alternate;
+}
+
+.orb-2 {
+  width: 320px;
+  height: 320px;
+  background: #d3b6ff;
+  right: -90px;
+  top: 140px;
+  animation: driftOrbTwo 34s ease-in-out infinite alternate;
+}
+
+.orb-3 {
+  width: 240px;
+  height: 240px;
+  background: #9df2d0;
+  bottom: -70px;
+  left: 40%;
+  animation: driftOrbThree 40s ease-in-out infinite alternate;
+}
+
+
+@keyframes driftOrbOne {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(48px, -34px, 0) scale(1.06);
+  }
+}
+
+@keyframes driftOrbTwo {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(-56px, 42px, 0) scale(1.08);
+  }
+}
+
+@keyframes driftOrbThree {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(26px, -38px, 0) scale(1.05);
+  }
+}
+
+.app-nav,
+.app-shell {
+  position: relative;
+  z-index: 1;
+}
+
+.app-nav {
+  margin: 12px auto;
+  max-width: 1100px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 6px 20px rgba(2, 6, 23, 0.05);
+}
+
+.navbar .active {
+  font-weight: 600;
+}
+
+.navbar-brand,
+.nav-link {
+  color: var(--text) !important;
+}
+
+.navbar-toggler {
+  border-color: rgba(17, 24, 39, 0.25);
+}
+
+.navbar-toggler-icon {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path stroke="rgba(17,24,39,0.8)" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"/></svg>');
+}
+
+.app-shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 8px 16px 32px;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  text-align: center;
+  padding: 36px 22px 28px;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 .header {
-  grid-area: header;
-  text-align: center;
-  font-size: 65px;
-  margin-top: 20px;
+  margin: 10px 0 10px;
+  font-size: clamp(1.7rem, 4.3vw, 3rem);
+  line-height: 1.2;
+  font-weight: 650;
 }
 
-.header input {
-  font-size: 25px;
-  width: 120px;
-  text-align: center;
-}
-
-h3 {
-  margin-bottom: 0;
-}
-
-.parsha {
-  grid-area: parsha;
-}
-
-.candles {
-  grid-area: candles;
-}
-.havdala {
-  grid-area: havdala;
-}
-.holiday {
-  grid-area: holiday;
+.subheader {
+  margin: 0 auto;
+  max-width: 720px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .finder {
+  margin-top: 20px;
   display: flex;
-  align-content: center;
-  place-content: center;
-  margin: 20px 0 40px 0;
-}
-
-.finder button {
-  margin-left: 20px;
-}
-
-#submit {
-  color: white;
-  border-color: white;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 #zip {
-  font-size: 16px;
-}
-.parsha,
-#candleLighting,
-#havdala,
-.color,
-#holiday,
-.holidaycandle,
-#holiday2,
-#holiday3 {
-  font-size: 60px;
-  font-weight: 200;
-  line-height: normal;
+  width: 150px;
   text-align: center;
+  border: 1px solid #cdd6e2;
+  border-radius: 10px;
+  background: #fff;
+  color: var(--text);
+  font-size: 1rem;
+  padding: 10px 12px;
+}
+
+#zip:focus,
+#submit:focus {
+  outline: 3px solid rgba(10, 132, 255, 0.2);
+  outline-offset: 1px;
+}
+
+#submit {
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  padding: 10px 18px;
+}
+
+#submit:hover {
+  background: #006ddb;
+}
+
+.info-grid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.info-card,
+.holidaycandle {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px 16px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+  text-align: center;
+}
+
+.card-label {
+  margin: 0 0 8px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.value-text,
+#holiday,
+#holiday2,
+#holiday3,
+#holidaycandle,
+.holidaycandle {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.28rem);
+  line-height: 1.45;
+  font-weight: 500;
 }
 
 #parsha {
-  font-weight: bold;
+  font-weight: 700;
 }
 
-#holidaycandle,
-.holidaycandle,
-#holiday2 {
-  text-align: center;
-}
-.candles,
-.parsha,
-.havdala {
-  border-bottom: white 1px solid;
+#parshalabel {
+  color: var(--text);
 }
 
-#parsha > div > ul > li{
-	font-size: medium;
-	text-align: left;
-	font-weight: normal;
-  }
-@media only screen and (min-width: 1200px) {
-  body {
-    margin: 4px 3.5%;
-  }
+#gpt {
+  margin-left: 8px;
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  vertical-align: middle;
 }
-@media only screen and (orientation: portrait) {
-  body {
-    margin: 0;
+
+.psummary {
+  margin: 14px 0 8px;
+  font-size: 1rem;
+}
+
+#parsha > div > ul > li {
+  font-size: 0.95rem;
+  text-align: left;
+  font-weight: 400;
+}
+
+@media (max-width: 992px) {
+  .app-nav {
+    margin: 8px;
   }
-  #page {
-    display: grid;
-    grid-template-areas:
-      "header "
-      "candles"
-      "parsha"
-      "havdala"
-      "holiday";
-    grid-template-rows: 170px auto auto auto;
+
+  .app-shell {
+    padding: 8px;
+  }
+
+  .info-grid {
     grid-template-columns: 1fr;
   }
-  .header {
-    font-size: 40px;
-  }
-  .holidaycandle {
-    font-size: 40px;
+
+  .hero-card {
+    padding: 28px 16px 22px;
   }
 
-  .candles,
-  .parsha,
-  .havdala {
-    border-bottom: none;
-  }
-
-  .fa-rectangle-list{
-	width: 10px;
-  }
-
-
-  .parsha,
-  #candleLighting,
-  #parsha,
-  #havdala,
-  #holiday,
-  #holiday2,
-  #holiday3 {
-    font-size: 40px;
-    margin: 0 5px;
-    border-bottom: white 1px solid;
-    padding: 4px 0;
-  }
-
-  .parsha p {
-    margin: auto 0 0;
+  .subheader {
+    font-size: 0.96rem;
   }
 }
 
+
+@media (prefers-reduced-motion: reduce) {
+  .orb-1,
+  .orb-2,
+  .orb-3 {
+    animation: none;
+  }
+}

--- a/shabbostime/shabbos.js
+++ b/shabbostime/shabbos.js
@@ -1,24 +1,14 @@
 // Cache DOM elements
 const inputField = document.getElementById("zip");
-const body = document.querySelector("body");
 const page = document.getElementById("page");
 
 // Set input field properties
 inputField.maxLength = 5;
 
 // Initialize variables
-let input = inputField.value;
-let zip;
-let city;
-let parsha;
+let currentParsha = "";
 
 // Define constants
-const colors = [
-  '#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe', '#00f2fe', 
-  '#43e97b', '#38f9d7', '#fa709a', '#fee140', '#a8edea', '#fed6e3',
-  '#ff9a9e', '#fecfef', '#fccb90', '#d4fc79', '#96e6a1', '#ffd89b',
-  '#19547b', '#ffecd2', '#fcb69f', '#a3bded', '#6991c7', '#13547a'
-];
 
 const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
@@ -30,18 +20,10 @@ function setZipcode(zipcode) {
   localStorage.setItem("zipcode", zipcode);
 }
 
-function getRandomColor(colors) {
-  return colors[Math.floor(Math.random() * colors.length)];
-}
-
 function changeColor() {
-  body.style.backgroundColor = getRandomColor(colors);
-  document.getElementById('colorlabel2').innerHTML = "Shabbos Times ";
+  document.getElementById('colorlabel2').innerHTML = "Shabbos Times";
   inputField.value = getZipcode();
-  if (inputField.value === "") {
-    console.log("empty")
-  }
-  else {
+  if (inputField.value !== "") {
     find();
   }
 }
@@ -60,11 +42,11 @@ function updateTextContent(id, text) {
 }
 
 function updateShabbosInfo(city, parsha, candles, havdalah) {
-  updateTextContent("header", city);
-  updateTextContent('parshalabel', "Torah portion: <br> <span id = \"parsha\"> </span> <button id=\"gpt\" class=\"fa-regular fa-rectangle-list fa-2xs\" onclick=\"generateAI()\"></button>");
-  updateTextContent('parsha', parsha);
-  updateTextContent("candleLighting", candles);
-  updateTextContent("havdala", havdalah);
+  updateTextContent("header", `Shabbos times for ${city}`);
+  updateTextContent('parshalabel', "Torah portion: <br> <span id=\"parsha\"></span> <button id=\"gpt\" class=\"fa-regular fa-rectangle-list fa-2xs\" onclick=\"generateAI()\"></button>");
+  updateTextContent('parsha', parsha || "—");
+  updateTextContent("candleLighting", candles || "—");
+  updateTextContent("havdala", havdalah || "—");
 }
 
 async function find() {
@@ -92,6 +74,7 @@ async function find() {
     // Extract parsha
     const parashatItem = data.items.find(i => i.category === "parashat");
     const parsha = parashatItem?.title || '';
+    currentParsha = parsha;
 
     // Extract candlelighting and havdalah times
     const candlesItem = data.items.find(i => i.category === "candles");
@@ -106,6 +89,8 @@ async function find() {
 
     // Update Shabbos info
     updateShabbosInfo(city, parsha, candlesText, havdalahText);
+
+    clearHolidayCards();
 
     // Handle holidays
     const holidayItems = data.items.filter(i => i.category === "holiday");
@@ -125,18 +110,28 @@ function formatEventText(date, title) {
   return `${days[d.getDay()]} ${d.getMonth() + 1}-${d.getDate()}-${d.getFullYear()}<br>${title}`;
 }
 
+function clearHolidayCards() {
+  ['holiday', 'holiday2', 'holiday3'].forEach((id) => {
+    const existing = document.getElementById(id);
+    if (existing) existing.remove();
+  });
+}
+
 // Helper function to handle holidays
 function handleHolidays(holidayItems) {
   if (holidayItems.length > 0) {
     const holidayDiv = setdiv('holiday', 'holidaycandle');
     const holidayName = holidayItems[0]?.title || '';
     updateTextContent('holiday', holidayName);
+    const holidayDetail = holidayItems.find(i => i.memo === holidayName)?.title || '';
 
-    const p = document.createElement("p");
-    p.setAttribute('id', 'holidaycandle');
-    p.setAttribute('class', 'holidaycandle');
-    p.innerHTML = holidayItems.find(i => i.memo === holidayName)?.title || '';
-    holidayDiv.append(p);
+    if (holidayDetail) {
+      const p = document.createElement("p");
+      p.setAttribute('id', 'holidaycandle');
+      p.setAttribute('class', 'holidaycandle');
+      p.innerHTML = holidayDetail;
+      holidayDiv.append(p);
+    }
   }
 }
 
@@ -147,11 +142,14 @@ function handleYomTov(yomtovItems) {
       const holidayDiv = setdiv(`holiday${index + 2}`, 'holidaycandle');
       const holidayName = item?.title || '';
       updateTextContent(`holiday${index + 2}`, holidayName);
+      const yomTovDetail = yomtovItems.find(i => i.memo === holidayName)?.title || '';
 
-      const p = document.createElement("p");
-      p.setAttribute('class', 'holidaycandle');
-      p.innerHTML = yomtovItems.find(i => i.memo === holidayName)?.title || '';
-      holidayDiv.append(p);
+      if (yomTovDetail) {
+        const p = document.createElement("p");
+        p.setAttribute('class', 'holidaycandle');
+        p.innerHTML = yomTovDetail;
+        holidayDiv.append(p);
+      }
     });
   }
 }
@@ -185,7 +183,7 @@ async function generateAI() {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      messages: [{ role: "user", content: "Summarize this parsha in 5 bullet sentences in HTML list format. Only include the <ul> and <li> in the return. Do not include ```html in the return " + parsha }],
+      messages: [{ role: "user", content: "Summarize this parsha in 5 bullet sentences in HTML list format. Only include the <ul> and <li> in the return. Do not include ```html in the return " + currentParsha }],
       web_access: false,
     }),
   };


### PR DESCRIPTION
### Motivation
- Add subtle, ambient motion to the colorful background orbs so the ShabbosTimes page feels more alive while preserving the existing readable layout and accessibility choices.  
- Keep the animation low-impact and performant by limiting transforms and providing a `prefers-reduced-motion` fallback.  

### Description
- Added slow, separate keyframe animations for each orb (`@keyframes driftOrbOne`, `driftOrbTwo`, `driftOrbThree`) and applied them to `.orb-1`, `.orb-2`, and `.orb-3` with different durations and drift vectors.  
- Improved animation performance by adding `will-change: transform` to `.orb` and using `translate3d`/`scale` transforms only.  
- Added a `@media (prefers-reduced-motion: reduce)` rule to disable the orb animations for users who prefer reduced motion.  

### Testing
- Ran `git diff --check` to verify patch sanity, which passed.  
- Served the site locally with `python -m http.server 4173` and manually verified the page loads and the lookup flow still works.  
- Executed a Playwright script that navigates to `http://127.0.0.1:4173/shabbostime/index.html`, fills `#zip` with `11230`, clicks submit, waits, and captures a screenshot to confirm the animated background renders, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b632a686483328b074191fa4a58d6)